### PR TITLE
Remove unused symbol check.

### DIFF
--- a/qodana.yaml
+++ b/qodana.yaml
@@ -4,3 +4,5 @@ profile:
   name: qodana.recommended
 include:
   - name: CheckDependencyLicenses
+exclude:
+  - name: UnusedSymbol


### PR DESCRIPTION
Basically all of the native functions return an error because they are "unused" on the Kotlin side, but they are public API's exposed to Lua. Make Qodana ignore them.